### PR TITLE
Remove python3-distutils dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -30,7 +30,6 @@
   <build_depend>protobuf-dev</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
-  <build_depend>python3-distutils</build_depend>
   <build_depend>python3-psutil</build_depend>
   <build_depend>python3-pytest</build_depend>
   <build_depend>uuid</build_depend>
@@ -40,7 +39,6 @@
   <exec_depend>protobuf-dev</exec_depend>
   <exec_depend>pybind11-dev</exec_depend>
   <exec_depend>python3-dev</exec_depend>
-  <exec_depend>python3-distutils</exec_depend>
   <exec_depend>python3-psutil</exec_depend>
   <exec_depend>python3-pytest</exec_depend>
   <exec_depend>uuid</exec_depend>


### PR DESCRIPTION
This dependency is only needed in the vendored package for CMake versions less than 3.12 (see https://github.com/gazebosim/gz-transport/blob/8cfecd0469e409b7af82725727eb0efade731504/python/CMakeLists.txt#L9-L15) . It is also failing to install on Noble currently preventing the whole vendor package from building. S